### PR TITLE
Spurious "NMI button pressed" events on host shutdown

### DIFF
--- a/src/power_control.cpp
+++ b/src/power_control.cpp
@@ -2203,7 +2203,11 @@ static void nmiButtonHandler(bool state)
     nmiButtonIface->set_property("ButtonPressed", !state);
     if (!state)
     {
-        nmiButtonPressLog();
+        if (getHostState(powerState) ==
+            "xyz.openbmc_project.State.Host.HostState.Running")
+        {
+            nmiButtonPressLog();
+        }
         if (nmiButtonMasked)
         {
             lg2::info("NMI button press masked");


### PR DESCRIPTION
Due to some probable lack of electronic stability, some invalid states are detected. This patch checks powerstate before logging such a message.

This fixes #11 